### PR TITLE
[#2] bugfix: 캐러셀 위젯과 영화 상세화면간 좋아요 동기화가 안되는 버그 해결

### DIFF
--- a/lib/widget/carousel_slider.dart
+++ b/lib/widget/carousel_slider.dart
@@ -149,6 +149,16 @@ class _CarouselImageState extends State<CarouselImage> {
       ),
     );
   }
+
+
+  @override
+  void didUpdateWidget(CarouselImage oldWidget) {
+    movies = widget.movies;
+    images = movies.map((movie) => Image.network(movie.poster)).toList();
+    keywords = movies.map((movie) => movie.keyword).toList();
+    likes = movies.map((movie) => movie.like).toList();
+    _currentKeyword = keywords[0];
+  }
 }
 
 List<Widget> makeIndicator(List list, int _currentPage) {


### PR DESCRIPTION
## Summary
Carousel widget과 movie detail screen간에 좋아요 상태가 안맞는 버그 해결

## Describe your changes
- Carousel widget에 재빌드시 widget의 state들이 초기화될 수 있도록 didUpdateWidget 함수 추가

## Issue number and link
resolved: #2 